### PR TITLE
Implement simple voting backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Secure Voting Application
+
+This project contains a minimal Node.js backend and static frontend for a simple voting system.
+
+## Backend
+
+The backend lives in `server/` and is built with Express and MongoDB via `mongoose`.
+
+### Running
+
+Install dependencies and start the server:
+
+```bash
+cd server
+npm install
+npm start
+```
+
+### Environment variables
+
+Set the following variables when running the server:
+
+- `DB_URI` – MongoDB connection string
+- `PAYSTACK_SECRET` – Paystack secret key
+- `PAYSTACK_CALLBACK` – public URL for payment verification callback
+- `JWT_SECRET` – secret used to sign authentication tokens
+- `PORT` – (optional) port for the server
+
+## Frontend
+
+Static pages are under `secure-voting-website/`:
+
+- `index.html` – login/register and list available polls
+- `admin.html` – admin interface to create polls, manage candidates and **toggle result visibility**
+
+Open these pages in a browser served from any HTTP server (e.g., `live-server`).
+
+## Payment Endpoint
+
+The backend exposes `/api/pay` to start a payment of ₦100 per vote and a `/api/pay/verify` endpoint for Paystack callbacks.

--- a/secure-voting-website/admin.html
+++ b/secure-voting-website/admin.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Admin Panel</title>
+</head>
+<body>
+  <h1>Create Poll</h1>
+  <form id="pollForm">
+    <input type="text" id="title" placeholder="Poll Title" />
+    <textarea id="candidates" placeholder="Candidate names comma separated"></textarea>
+    <button type="submit">Create</button>
+  </form>
+
+  <h2>Existing Polls</h2>
+  <ul id="adminPolls"></ul>
+
+  <script src="admin.js"></script>
+</body>
+</html>

--- a/secure-voting-website/admin.js
+++ b/secure-voting-website/admin.js
@@ -1,0 +1,32 @@
+let token = '';
+
+async function fetchPolls() {
+  const res = await fetch('/api/polls');
+  const polls = await res.json();
+  const list = document.getElementById('adminPolls');
+  list.innerHTML = polls.map(p => `<li>${p.title} - <button onclick="toggle('${p._id}')">Toggle Visibility</button></li>`).join('');
+}
+
+async function toggle(id) {
+  await fetch(`/api/polls/${id}/toggle`, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${token}` }
+  });
+  fetchPolls();
+}
+
+document.getElementById('pollForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const names = document.getElementById('candidates').value.split(',').map(n => ({ name: n.trim() }));
+  await fetch('/api/polls', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`
+    },
+    body: JSON.stringify({ title: document.getElementById('title').value, candidates: names })
+  });
+  fetchPolls();
+});
+
+fetchPolls();

--- a/secure-voting-website/index.html
+++ b/secure-voting-website/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Secure Voting</title>
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="loginForm">
+    <input type="text" id="username" placeholder="Username" />
+    <input type="password" id="password" placeholder="Password" />
+    <button type="submit">Login</button>
+  </form>
+  <h1>Register</h1>
+  <form id="registerForm">
+    <input type="text" id="regUsername" placeholder="Username" />
+    <input type="password" id="regPassword" placeholder="Password" />
+    <button type="submit">Register</button>
+  </form>
+
+  <h2>Polls</h2>
+  <ul id="polls"></ul>
+
+  <script src="index.js"></script>
+</body>
+</html>

--- a/secure-voting-website/index.js
+++ b/secure-voting-website/index.js
@@ -1,0 +1,37 @@
+let token = '';
+
+async function fetchPolls() {
+  const res = await fetch('/api/polls');
+  const polls = await res.json();
+  const list = document.getElementById('polls');
+  list.innerHTML = polls.map(p => `<li>${p.title}</li>`).join('');
+}
+
+document.getElementById('loginForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const res = await fetch('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      username: document.getElementById('username').value,
+      password: document.getElementById('password').value,
+    }),
+  });
+  const data = await res.json();
+  token = data.token;
+  fetchPolls();
+});
+
+document.getElementById('registerForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  await fetch('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      username: document.getElementById('regUsername').value,
+      password: document.getElementById('regPassword').value,
+    }),
+  });
+});
+
+fetchPolls();

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const cors = require('cors');
+const bodyParser = require('body-parser');
+
+const authRoutes = require('./routes/auth');
+const pollRoutes = require('./routes/polls');
+const voteRoutes = require('./routes/votes');
+const payRoutes = require('./routes/pay');
+
+const app = express();
+
+app.use(cors());
+app.use(bodyParser.json());
+
+mongoose.connect(process.env.DB_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+app.use('/api/auth', authRoutes);
+app.use('/api/polls', pollRoutes);
+app.use('/api/votes', voteRoutes);
+app.use('/api/pay', payRoutes);
+
+module.exports = app;
+
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+}

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,20 @@
+const jwt = require('jsonwebtoken');
+
+function auth(requiredAdmin = false) {
+  return (req, res, next) => {
+    const token = req.headers.authorization && req.headers.authorization.split(' ')[1];
+    if (!token) return res.status(401).json({ message: 'Unauthorized' });
+    try {
+      const decoded = jwt.verify(token, process.env.JWT_SECRET);
+      req.user = decoded;
+      if (requiredAdmin && !decoded.isAdmin) {
+        return res.status(403).json({ message: 'Forbidden' });
+      }
+      next();
+    } catch (err) {
+      return res.status(401).json({ message: 'Unauthorized' });
+    }
+  };
+}
+
+module.exports = auth;

--- a/server/models/Candidate.js
+++ b/server/models/Candidate.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const candidateSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  profile: { type: String },
+});
+
+module.exports = mongoose.model('Candidate', candidateSchema);

--- a/server/models/Poll.js
+++ b/server/models/Poll.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const pollSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  candidates: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Candidate' }],
+  resultVisible: { type: Boolean, default: false },
+});
+
+module.exports = mongoose.model('Poll', pollSchema);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+const bcrypt = require('bcrypt');
+
+const userSchema = new mongoose.Schema({
+  username: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  isAdmin: { type: Boolean, default: false },
+});
+
+userSchema.pre('save', async function(next) {
+  if (!this.isModified('password')) return next();
+  this.password = await bcrypt.hash(this.password, 10);
+  next();
+});
+
+userSchema.methods.comparePassword = function(candidatePassword) {
+  return bcrypt.compare(candidatePassword, this.password);
+};
+
+module.exports = mongoose.model('User', userSchema);

--- a/server/models/Vote.js
+++ b/server/models/Vote.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const voteSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  poll: { type: mongoose.Schema.Types.ObjectId, ref: 'Poll' },
+  candidate: { type: mongoose.Schema.Types.ObjectId, ref: 'Candidate' },
+  paid: { type: Boolean, default: false },
+});
+
+module.exports = mongoose.model('Vote', voteSchema);

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "secure-voting-server",
+  "version": "1.0.0",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "axios": "^1.4.0",
+    "bcrypt": "^5.1.0",
+    "body-parser": "^1.20.2",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0",
+    "mongoose": "^7.3.1"
+  }
+}

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,27 @@
+const router = require('express').Router();
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+router.post('/register', async (req, res) => {
+  try {
+    const user = await User.create(req.body);
+    res.json(user);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  try {
+    const user = await User.findOne({ username: req.body.username });
+    if (!user) return res.status(400).json({ message: 'Invalid credentials' });
+    const valid = await user.comparePassword(req.body.password);
+    if (!valid) return res.status(400).json({ message: 'Invalid credentials' });
+    const token = jwt.sign({ id: user._id, isAdmin: user.isAdmin }, process.env.JWT_SECRET);
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/routes/pay.js
+++ b/server/routes/pay.js
@@ -1,0 +1,47 @@
+const router = require('express').Router();
+const axios = require('axios');
+const Vote = require('../models/Vote');
+const auth = require('../middleware/auth');
+
+const PAYSTACK_SECRET = process.env.PAYSTACK_SECRET;
+const PAYSTACK_CALLBACK = process.env.PAYSTACK_CALLBACK;
+
+router.post('/', auth(), async (req, res) => {
+  try {
+    const { email, voteId } = req.body;
+    const vote = await Vote.findById(voteId);
+    if (!vote) return res.status(404).json({ message: 'Vote not found' });
+
+    const response = await axios.post('https://api.paystack.co/transaction/initialize',
+      {
+        email,
+        amount: 10000, // 100 Naira in kobo
+        callback_url: PAYSTACK_CALLBACK,
+        metadata: { voteId },
+      },
+      { headers: { Authorization: `Bearer ${PAYSTACK_SECRET}` } });
+    res.json(response.data);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+router.post('/verify', async (req, res) => {
+  try {
+    const { reference, voteId } = req.body;
+    const verify = await axios.get(`https://api.paystack.co/transaction/verify/${reference}`,
+      { headers: { Authorization: `Bearer ${PAYSTACK_SECRET}` } });
+    if (verify.data.data.status === 'success') {
+      const vote = await Vote.findById(voteId);
+      if (vote) {
+        vote.paid = true;
+        await vote.save();
+      }
+    }
+    res.json(verify.data);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/routes/polls.js
+++ b/server/routes/polls.js
@@ -1,0 +1,35 @@
+const router = require('express').Router();
+const Poll = require('../models/Poll');
+const Candidate = require('../models/Candidate');
+const auth = require('../middleware/auth');
+
+router.get('/', async (req, res) => {
+  const polls = await Poll.find().populate('candidates');
+  res.json(polls);
+});
+
+router.post('/', auth(true), async (req, res) => {
+  try {
+    const candidates = await Candidate.insertMany(req.body.candidates || []);
+    const poll = await Poll.create({
+      title: req.body.title,
+      candidates: candidates.map(c => c._id),
+    });
+    res.json(await poll.populate('candidates'));
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+router.post('/:id/toggle', auth(true), async (req, res) => {
+  try {
+    const poll = await Poll.findById(req.params.id);
+    poll.resultVisible = !poll.resultVisible;
+    await poll.save();
+    res.json(poll);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/routes/votes.js
+++ b/server/routes/votes.js
@@ -1,0 +1,28 @@
+const router = require('express').Router();
+const Vote = require('../models/Vote');
+const Poll = require('../models/Poll');
+const auth = require('../middleware/auth');
+
+router.post('/', auth(), async (req, res) => {
+  try {
+    const poll = await Poll.findById(req.body.poll);
+    if (!poll) return res.status(404).json({ message: 'Poll not found' });
+    const vote = await Vote.create({
+      user: req.user.id,
+      poll: req.body.poll,
+      candidate: req.body.candidate,
+    });
+    res.json(vote);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+router.get('/poll/:id', async (req, res) => {
+  const poll = await Poll.findById(req.params.id);
+  if (!poll.resultVisible) return res.status(403).json({ message: 'Results hidden' });
+  const votes = await Vote.find({ poll: req.params.id }).populate('candidate');
+  res.json(votes);
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- set up `server/` Express app with mongoose models
- add auth, poll, vote and `/api/pay` payment routes
- create simple login/register and admin pages
- document environment variables for Paystack and Mongo

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6877a96d0b9c833285f7d028a13cd8be