### PR TITLE
Add styling to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Static pages are under `secure-voting-website/`:
 
 - `index.html` – login/register and list available polls
 - `admin.html` – admin interface to create polls, manage candidates and **toggle result visibility**
+- `style.css` – shared stylesheet for a cleaner layout
 
 Open these pages in a browser served from any HTTP server (e.g., `live-server`).
 

--- a/secure-voting-website/admin.html
+++ b/secure-voting-website/admin.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Admin Panel</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <h1>Create Poll</h1>

--- a/secure-voting-website/index.html
+++ b/secure-voting-website/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Secure Voting</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <h1>Login</h1>

--- a/secure-voting-website/style.css
+++ b/secure-voting-website/style.css
@@ -1,0 +1,59 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f4f5fa;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+h1 {
+  color: #333;
+}
+
+form {
+  background: white;
+  padding: 20px;
+  margin: 10px 0;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+}
+
+input, textarea {
+  margin-bottom: 10px;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+button {
+  background: #4CAF50;
+  color: white;
+  border: none;
+  padding: 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+button:hover {
+  background: #45a049;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+li {
+  background: white;
+  margin-bottom: 5px;
+  padding: 10px;
+  border-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}


### PR DESCRIPTION
## Summary
- create shared `style.css` with basic layout styles
- reference the stylesheet from both frontend pages
- document the new stylesheet in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877b191f088833295cf5026f446458f