### PR TITLE
Add Google login

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Set the following variables when running the server:
 - `PAYSTACK_CALLBACK` – public URL for payment verification callback
 - `JWT_SECRET` – secret used to sign authentication tokens
 - `PORT` – (optional) port for the server
+- `GOOGLE_CLIENT_ID` – Google OAuth client ID
+- `GOOGLE_CLIENT_SECRET` – Google OAuth client secret
 
 ## Frontend
 
@@ -35,6 +37,8 @@ Static pages are under `secure-voting-website/`:
 - `style.css` – shared stylesheet for a cleaner layout
 
 Open these pages in a browser served from any HTTP server (e.g., `live-server`).
+
+The login page also provides a **Login with Google** button that initiates an OAuth flow via `/api/auth/google`.
 
 ## Payment Endpoint
 

--- a/secure-voting-website/index.html
+++ b/secure-voting-website/index.html
@@ -14,6 +14,7 @@
       <input type="text" id="username" placeholder="Username" />
       <input type="password" id="password" placeholder="Password" />
       <button type="submit">Login</button>
+      <button type="button" id="googleLogin">Login with Google</button>
     </form>
     <h2>Register</h2>
     <form id="registerForm">

--- a/secure-voting-website/index.js
+++ b/secure-voting-website/index.js
@@ -34,4 +34,14 @@ document.getElementById('registerForm').addEventListener('submit', async e => {
   });
 });
 
-fetchPolls();
+document.getElementById('googleLogin').addEventListener('click', () => {
+  window.location.href = '/api/auth/google';
+});
+
+const params = new URLSearchParams(window.location.search);
+if (params.get('token')) {
+  token = params.get('token');
+  fetchPolls();
+} else {
+  fetchPolls();
+}

--- a/server/app.js
+++ b/server/app.js
@@ -2,6 +2,9 @@ const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
 const bodyParser = require('body-parser');
+const passport = require('passport');
+const GoogleStrategy = require('passport-google-oauth20').Strategy;
+const User = require('./models/User');
 
 const authRoutes = require('./routes/auth');
 const pollRoutes = require('./routes/polls');
@@ -12,6 +15,31 @@ const app = express();
 
 app.use(cors());
 app.use(bodyParser.json());
+app.use(passport.initialize());
+
+passport.use(new GoogleStrategy(
+  {
+    clientID: process.env.GOOGLE_CLIENT_ID,
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    callbackURL: '/api/auth/google/callback',
+  },
+  async (accessToken, refreshToken, profile, done) => {
+    try {
+      const email = profile.emails && profile.emails[0] && profile.emails[0].value;
+      if (!email) return done(new Error('No email associated with this account'));
+      let user = await User.findOne({ username: email });
+      if (!user) {
+        user = await User.create({
+          username: email,
+          password: Math.random().toString(36).slice(-8),
+        });
+      }
+      return done(null, user);
+    } catch (err) {
+      return done(err);
+    }
+  }
+));
 
 mongoose.connect(process.env.DB_URI, {
   useNewUrlParser: true,

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,8 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
-    "mongoose": "^7.3.1"
+    "mongoose": "^7.3.1",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0"
   }
 }

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,6 +1,7 @@
 const router = require('express').Router();
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
+const passport = require('passport');
 
 router.post('/register', async (req, res) => {
   try {
@@ -22,6 +23,13 @@ router.post('/login', async (req, res) => {
   } catch (err) {
     res.status(500).json({ message: err.message });
   }
+});
+
+router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+
+router.get('/google/callback', passport.authenticate('google', { session: false }), (req, res) => {
+  const token = jwt.sign({ id: req.user._id, isAdmin: req.user.isAdmin }, process.env.JWT_SECRET);
+  res.redirect(`/?token=${token}`);
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- support Google OAuth login via Passport on the backend
- expose `/api/auth/google` endpoint that redirects back with a JWT token
- add Google login button on the login page and handle token in JS
- document new OAuth environment variables

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687826f7fdf88332a490899c8612c61c